### PR TITLE
fix: no clone() in env scope

### DIFF
--- a/src/lox/interpreter/entities/env.rs
+++ b/src/lox/interpreter/entities/env.rs
@@ -4,8 +4,15 @@ use std::{collections::HashMap, fmt::Debug};
 
 #[derive(Debug, Clone)]
 pub struct Env<T> {
+    current: Link<T>,
+}
+
+type Link<T> = Option<Box<Scope<T>>>;
+
+#[derive(Debug, Clone)]
+struct Scope<T> {
     values: HashMap<String, T>,
-    pub enclosing: Option<Box<Env<T>>>,
+    pub parent: Link<T>,
 }
 
 impl<T> Env<T>
@@ -14,34 +21,90 @@ where
 {
     pub fn new() -> Self {
         Self {
-            values: HashMap::new(),
-            enclosing: None,
+            current: Some(Box::new(Scope::new())),
         }
     }
 
-    pub fn with_env(env: Env<T>) -> Self {
-        Self {
-            values: HashMap::new(),
-            enclosing: Some(Box::new(env)),
+    pub fn open_scope(&mut self) {
+        let new_scope = Box::new(Scope::with_parent(self.current.take()));
+        self.current = Some(new_scope);
+    }
+
+    pub fn close_scope(&mut self) {
+        if let Some(s) = self.current.take() {
+            self.current = s.parent;
         }
     }
 
     pub fn define(&mut self, name: &str, val: T) {
-        self.values.insert(name.to_string(), val);
+        if let Some(s) = self.current.as_mut() {
+            s.define(name, val)
+        }
     }
 
     pub fn assign(&mut self, name: &str, val: T) -> Result<()> {
+        self.current
+            .as_mut()
+            .ok_or(LoxErr::Internal {
+                message: "Attempted to assign to an unscoped environment".to_string(),
+            })
+            .and_then(|s| s.assign(name, val))?;
+        Ok(())
+    }
+
+    pub fn get(&self, name: &str) -> Result<&T> {
+        self.current
+            .as_ref()
+            .ok_or(LoxErr::Internal {
+                message: "Attempted to get from an unscoped environment".to_string(),
+            })
+            .and_then(|s| s.get(name))
+    }
+}
+
+impl<T> Drop for Env<T> {
+    fn drop(&mut self) {
+        let mut curr = self.current.take();
+        while let Some(mut link) = curr {
+            curr = link.parent.take();
+        }
+    }
+}
+
+impl<T> Scope<T>
+where
+    T: Debug + Clone,
+{
+    fn new() -> Self {
+        Self {
+            values: HashMap::new(),
+            parent: None,
+        }
+    }
+
+    fn with_parent(parent: Link<T>) -> Self {
+        Self {
+            values: HashMap::new(),
+            parent,
+        }
+    }
+
+    fn define(&mut self, name: &str, val: T) {
+        self.values.insert(name.to_string(), val);
+    }
+
+    fn assign(&mut self, name: &str, val: T) -> Result<()> {
         if self.values.contains_key(name) {
             self.values.insert(name.to_string(), val);
             return Ok(());
         }
         if self
-            .enclosing
+            .parent
             .as_mut()
             .and_then(|e| e.values.contains_key(name).then_some(true))
             .is_some()
         {
-            self.enclosing.as_mut().unwrap().assign(name, val)?;
+            self.parent.as_mut().unwrap().assign(name, val)?;
             return Ok(());
         }
         Err(LoxErr::Undefined {
@@ -49,11 +112,11 @@ where
         })
     }
 
-    pub fn get(&self, name: &str) -> Result<&T> {
+    fn get(&self, name: &str) -> Result<&T> {
         debug!("[get] curr values: {:?}", self);
         self.values
             .get(name)
-            .or_else(|| self.enclosing.as_ref().and_then(|env| env.get(name).ok()))
+            .or_else(|| self.parent.as_ref().and_then(|env| env.get(name).ok()))
             .ok_or(LoxErr::Undefined {
                 message: format!("variable undefined: {}", name),
             })

--- a/src/lox/interpreter/eval.rs
+++ b/src/lox/interpreter/eval.rs
@@ -220,17 +220,14 @@ impl StmtExec<()> for Interpreter {
     }
 
     fn block_stmt(&mut self, expr: &StmtBlock) -> Result<()> {
-        self.env = Env::with_env(self.env.clone());
+        self.env.open_scope();
         debug!("curr env block status: {:?}", self.env);
 
         for stmt in expr.stmts.as_slice() {
             self.exec_stmt(stmt)?;
         }
 
-        self.env = *self.env.enclosing.take().ok_or(LoxErr::Undefined {
-            message: "unexpected empty parent env for block statement".to_string(),
-        })?;
-
+        self.env.close_scope();
         Ok(())
     }
 


### PR DESCRIPTION
This removes any `clone()`/`copy()` calls when entering and exiting environment scopes, which can be dramatically slow for larger programs. Scoping is by-ref on all cases.