### PR TITLE
feat: for statement desugaring

### DIFF
--- a/samples/test.lox
+++ b/samples/test.lox
@@ -41,3 +41,15 @@ while (n < 1) {
   print "is n < 1?: "; print  (n < 1);
 }
 
+// testing for with fibonacci sequence
+
+print "printing the fibonacci sequence up to 10000";
+var a = 0;
+var temp;
+
+for (var b = 1; a < 1000; b = temp + b) {
+  print a;
+  temp = a;
+  a = b;
+}
+

--- a/src/lox/interpreter/entities/env.rs
+++ b/src/lox/interpreter/entities/env.rs
@@ -94,16 +94,12 @@ where
     }
 
     fn assign(&mut self, name: &str, val: T) -> Result<()> {
+        debug!("[assign] curr values: {:?}", self);
         if self.values.contains_key(name) {
             self.values.insert(name.to_string(), val);
             return Ok(());
         }
-        if self
-            .parent
-            .as_mut()
-            .and_then(|e| e.values.contains_key(name).then_some(true))
-            .is_some()
-        {
+        if self.parent.is_some() {
             self.parent.as_mut().unwrap().assign(name, val)?;
             return Ok(());
         }

--- a/src/lox/interpreter/entities/stmt.rs
+++ b/src/lox/interpreter/entities/stmt.rs
@@ -10,6 +10,8 @@ pub enum Stmt {
     While(StmtWhile),
 }
 
+type StmtB = Box<Stmt>;
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct StmtExpr {
     pub expr: Expr,
@@ -33,13 +35,13 @@ pub struct StmtBlock {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct StmtWhile {
-    pub stmt: Box<Stmt>,
+    pub stmt: StmtB,
     pub expr: Expr,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct StmtIf {
     pub cond: Expr,
-    pub then: Box<Stmt>,
-    pub else_stmt: Option<Box<Stmt>>,
+    pub then: StmtB,
+    pub else_stmt: Option<StmtB>,
 }


### PR DESCRIPTION
This allows for `for` statements via desugaring, e.g.

```

for (var b = 1; a < 1000; b = temp + b) {
  print a;
  temp = a;
  a = b;
}
```
Also fixes bug with recursive env